### PR TITLE
Default SharedPreferences key

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ String bar = datastore.bar().get();
 
 It now also supports all your basic types (String, int, boolean, float, long) as well as Objects via gson. 
 
+If no `@Preference` annotation is supplied, EasyDatastore will use the name of the method as the shared preferences key
+
 Todo:
 multiple changes in a single apply?
 throw exception if multiple methods share the same key?

--- a/app/src/main/java/com/lacronicus/easydatastore/MainActivity.java
+++ b/app/src/main/java/com/lacronicus/easydatastore/MainActivity.java
@@ -12,6 +12,8 @@ import com.lacronicus.easydatastorelib.DatastoreBuilder;
 
 public class MainActivity extends ActionBarActivity {
 
+    private static final String TAG = "APP";
+    
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -20,32 +22,36 @@ public class MainActivity extends ActionBarActivity {
 
         MyDatastore datastore = new DatastoreBuilder(PreferenceManager.getDefaultSharedPreferences(this))
                 .create(MyDatastore.class);
+        
+        datastore.myPrefWithNoExplicitName().put("Hello, no explicit preference name!");
+        String myPrefWithNoExplicitName = datastore.myPrefWithNoExplicitName().get();
+        Log.d(TAG, myPrefWithNoExplicitName);
 
         datastore.bar().put("Hello World");
         String bar = datastore.bar().get();
-        Log.d("APP", bar);
+        Log.d(TAG, bar);
         Toast.makeText(this, bar, Toast.LENGTH_SHORT).show();
 
         datastore.myInt().put(2);
         int myInt = datastore.myInt().get(-1);
-        Log.d("APP", "" + myInt);
+        Log.d(TAG, "" + myInt);
 
         datastore.myFloat().put(2.4f);
         float myFloat = datastore.myFloat().get(-1);
-        Log.d("APP", "" + myFloat);
+        Log.d(TAG, "" + myFloat);
 
         datastore.myLong().put(Long.MAX_VALUE);
         long myLong = datastore.myLong().get(-1);
-        Log.d("APP", "" + myLong);
+        Log.d(TAG, "" + myLong);
 
         datastore.myBoolean().put(true);
         boolean mybool = datastore.myBoolean().get(false);
-        Log.d("APP", "" + mybool);
+        Log.d(TAG, "" + mybool);
 
         MyModel model = new MyModel("derp", 42);
         datastore.myModel().put(model);
         MyModel pulledModel = datastore.myModel().get();
-        Log.d("APP", pulledModel.toString());
+        Log.d(TAG, pulledModel.toString());
     }
 
     @Override

--- a/app/src/main/java/com/lacronicus/easydatastore/MyDatastore.java
+++ b/app/src/main/java/com/lacronicus/easydatastore/MyDatastore.java
@@ -12,6 +12,9 @@ import com.lacronicus.easydatastorelib.StringEntry;
  * Created by fdoyle on 7/10/15.
  */
 public interface MyDatastore {
+
+    StringEntry myPrefWithNoExplicitName();
+
     @Preference("foo")
     StringEntry foo();
 

--- a/easydatastorelib/build.gradle
+++ b/easydatastorelib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-version = "1.0.3"
+version = "1.0.4"
 
 android {
     compileSdkVersion 21

--- a/easydatastorelib/src/main/java/com/lacronicus/easydatastorelib/DatastoreBuilder.java
+++ b/easydatastorelib/src/main/java/com/lacronicus/easydatastorelib/DatastoreBuilder.java
@@ -44,7 +44,10 @@ public class DatastoreBuilder {
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            String key = method.getAnnotation(Preference.class).value();
+            Preference preference = method.getAnnotation(Preference.class);
+            boolean hasPreferenceValue = preference != null && preference.value() != null;
+
+            String key = hasPreferenceValue ? preference.value() : method.getName();
             if (method.getReturnType().equals(StringEntry.class)) {
                 return new StringEntry(preferences, key);
             } else if (method.getReturnType().equals(FloatEntry.class)) {


### PR DESCRIPTION
Often i'm not too concerned with the actual key that gets stored into shared preferences. Given the declarative nature of this library, it can seem superfluous to set a string for the underlying `SharedPreferences`.

This PR removes the need to add a `@Preference` annotation to each item in the datastore interface. If no preference is supplied, the name of the method is used as the key. Otherwise the preference value is used as always.

As a side-affect, this PR also fixes a `NullPointerException` if a method is not annotated.

README and sample app also updated.
